### PR TITLE
[Style] 로그인, 최초 정보 수집 페이지 퍼블리싱

### DIFF
--- a/client/src/app/auth/login/page.tsx
+++ b/client/src/app/auth/login/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import LoginBanner from "@/components/auth/LoginBanner";
+import { Bubble } from "@/components/ui/Bubble";
+import { TextButton } from "@/components/ui/TextButton";
+import { FcGoogle } from "react-icons/fc";
+
+export default function page() {
+  return (
+    <div className="h-screen flex flex-col px-6">
+      <LoginBanner />
+      <div className="w-full relative flex flex-1 ">
+        <div
+          className="absolute
+            bottom-[140px] left-1/2 -translate-x-1/2 "
+        >
+          <Bubble>3초만에 로그인해요</Bubble>
+        </div>
+
+        <TextButton className="absolute bottom-[90px] h-12.5 rounded-full border-[var(--color-gray-30)] border-1 bg-[var(--color-white)] ">
+          <div className="flex items-center justify-center gap-2">
+            <FcGoogle size={20} />
+            <span>구글 로그인</span>
+          </div>
+        </TextButton>
+      </div>
+    </div>
+  );
+}

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -24,15 +24,7 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className={`${pretendard.variable} w-full`}>
-        {/* <Header
-          logo={true}
-          nuPick={true}
-          interest={["경제", "사회", "문화"]}
-          dark={false}
-        />
-        <div className="pt-[98px] bg-black/70">{children}</div>
-        <Footer isNuPick={true} /> */}
-        {children}
+        <div className="max-w-screen-lg mx-auto">{children}</div>
       </body>
     </html>
   );

--- a/client/src/app/profile/init/page.tsx
+++ b/client/src/app/profile/init/page.tsx
@@ -1,0 +1,71 @@
+import Input from "@/components/ui/Input";
+import SelectComponent from "@/components/ui/SelectComponent";
+import { TextButton } from "@/components/ui/TextButton";
+import { LuDices } from "react-icons/lu";
+import { IoFemaleOutline } from "react-icons/io5";
+import { IoMaleOutline } from "react-icons/io5";
+
+export default function page() {
+  const ageOptions = [
+    { label: "10대", value: "10s" },
+    { label: "20대", value: "20s" },
+    { label: "30대", value: "30s" },
+    { label: "40대 이상", value: "40s" },
+    { label: "선택하지 않음", value: "none" },
+  ];
+  return (
+    <div className=" relative h-screen flex flex-col px-6">
+      <h1 className="text-[22px] font-bold leading-[140%] py-8">
+        보민님의 정보를
+        <br />
+        알려주세요
+      </h1>
+      <div className="flex flex-col gap-8">
+        <div className="flex flex-col gap-2">
+          <p className="text-[var(--color-gray-80)] text-xs">닉네임</p>
+          <Input
+            placeholder="나의 닉네임은?"
+            rightSlot={<LuDices className="text-[#757575]" />}
+          />
+        </div>
+        <SelectComponent
+          label="연령"
+          options={ageOptions}
+          placeholder="연령대를 선택해주세요"
+        />
+        <div className="flex flex-col gap-2">
+          <p className="text-[var(--color-gray-80)] text-xs">성별</p>
+          <div className="flex h-12.5 gap-2 text-sm">
+            <TextButton
+              className="text-[var(--color-gray-50)] border-1 border-[var(--color-gray-30)] bg-white hover:border-[var(--color-gray-50)]
+            
+            hover:text-[var(--color-gray-100)] hover:bg-white
+            "
+            >
+              <div className="flex items-center gap-1">
+                <IoMaleOutline size={18} />
+                <span>남성</span>
+              </div>
+            </TextButton>
+            <TextButton
+              className="text-[var(--color-gray-50)] border-1 border-[var(--color-gray-30)] bg-white hover:border-[var(--color-gray-50)]
+            
+            hover:text-[var(--color-gray-100)] hover:bg-white
+            "
+            >
+              <div className="flex items-center gap-1">
+                <IoFemaleOutline size={18} />
+                <span>여성</span>
+              </div>
+            </TextButton>
+          </div>
+        </div>
+      </div>
+      <div className="w-full absolute bottom-0 left-0 px-5 py-5  rounded-full">
+        <TextButton state="disabled" className="h-12.5">
+          완료
+        </TextButton>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/auth/LoginBanner.tsx
+++ b/client/src/components/auth/LoginBanner.tsx
@@ -1,0 +1,19 @@
+const LoginBanner = () => {
+  return (
+    <div className="flex flex-col w-full  ">
+      <h2 className="font-black text-[var(--color-black)] text-lg py-8">
+        NUNEW
+      </h2>
+      <h1 className=" text-[var(--color-black)] leading-[140%] text-4xl font-bold">
+        관심있는 뉴스만
+        <br />
+        내맘대로.
+      </h1>
+      <h3 className="text-[var(--color-gray-80)] text-sm pt-2.5">
+        서브 슬로건을 정해볼까요?
+      </h3>
+    </div>
+  );
+};
+
+export default LoginBanner;

--- a/client/src/components/ui/Bubble.tsx
+++ b/client/src/components/ui/Bubble.tsx
@@ -1,0 +1,26 @@
+interface BubbleProps {
+  children: React.ReactNode;
+  size?: "sm" | "lg";
+  className?: string;
+}
+
+export const Bubble = ({
+  children,
+  size = "sm",
+  className = "",
+}: BubbleProps) => {
+  const baseStyle =
+    "text-center w-[204px] px-2 py-2.5 text-[color:var(--color-white)] bg-[color:var(--color-gray-100)] rounded-lg ";
+  const sizeStyles = {
+    sm: "text-xs",
+    lg: "text-base",
+  };
+  return (
+    <div className="flex flex-col items-center animate-bounce">
+      <div className={`${baseStyle} ${sizeStyles[size]} ${className}`}>
+        {children}
+      </div>
+      <div className="w-0 h-0 border-t-[8px] border-t-[color:var(--color-gray-100)] border-l-[8px] border-l-transparent border-r-[8px] border-r-transparent"></div>
+    </div>
+  );
+};


### PR DESCRIPTION
## #️⃣ 개요

로그인 페이지
최초 정보 등록 페이지 퍼블리싱

---

## 📝 요약(Summary)

말풍선 컴포넌트를 만들었습니다. ( ui/Bubble)
로그인, 정보 등록 페이지 퍼블리싱

모든 페이지가 컴퓨터에서도 모바일 뷰로 보여지는 것 감안해서
최상단 레이아웃을 1024px max-width로 제한해 두었습니다.

긱 페이지에 div에 w-full 로 주면 1024로 자동 적용됩니다.
안에서 패딩만 적절하게 주시면 될 것 같습니다. 

duration-300 고정해서 사용하면 좋을 것 같습니다.



---

## 🛠️ PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📸스크린샷 (선택)

<img width="444" height="919" alt="image" src="https://github.com/user-attachments/assets/b62cdb0e-b18f-4909-82de-e3492ad8e26a" />

**
<img width="443" height="928" alt="image" src="https://github.com/user-attachments/assets/2400d97e-8ae8-49b8-888c-b02412fac5a6" />
**



---

## 💬 공유사항 to 리뷰어

⭐ 헤더 컴포넌트
 프롭스들이 옵셔널로 지정이 안되어 있어서 일단 빼고 작업했습니다.

⭐인풋 컴포넌트
 서비스의 인풋 스타일 고정되어있는 것 같아서 제일 많이 쓰이는 스타일로 고정해주시고 
자잘한 스타일 변경 있는 경우 부모에서 프롭스로 내려주면 적용되도록 변경 부탁 드립니다!

⭐셀렉트 컴포넌트
 label 스타일링 변경 가능한가요??


